### PR TITLE
Changed code for the idtax2df function for PR2 5.0.0 compatibility

### DIFF
--- a/R/idtax2df.R
+++ b/R/idtax2df.R
@@ -192,7 +192,7 @@ idtax2df <- function(tt, db = "pr2", ranks = NULL, boot = 0, rubric = NULL,
     yydf[confdf < boot] <- NA
 
     if (db == "pr2") {
-      ranks <- c("kingdom", "supergroup", "division", "class", "order", "family", "genus", "species")
+      ranks <- c("domain", "supergroup", "division", "subdivision", "class", "order", "family", "genus", "species")
       colnames(yydf) <- ranks
       colnames(confdf) <- ranks
     } else if (is.null(db)) {

--- a/R/idtax2df.R
+++ b/R/idtax2df.R
@@ -64,14 +64,14 @@ idtax2df <- function(tt, db = "pr2", ranks = NULL, boot = 0, rubric = NULL,
     notu <- length(tt)
     for(j in 1:notu){
       bob <- tt[[j]]$taxon
-      if (length(bob) < 9) {
+      if (length(bob) < 10) {
         # add NA's to hit 9 ranks
-        linda <- 9 - length(bob)
+        linda <- 10 - length(bob)
         tina <- c(bob, rep(NA, times = linda))
         taxonomy<-append(taxonomy, tina)
         gene <- c(tt[[j]]$confidence, rep(NA, times = linda))
         conf <- append(conf, gene)
-      } else if (length(bob) > 9) {
+      } else if (length(bob) > 10) {
         stop("why pr2?! whyyyyyy")
       } else {
         taxonomy<-append(taxonomy, bob)
@@ -84,7 +84,7 @@ idtax2df <- function(tt, db = "pr2", ranks = NULL, boot = 0, rubric = NULL,
     confdf <- confdf[,-1]
     yydf[confdf < boot] <- NA
 
-    ranks <- c("kingdom", "supergroup", "division", "class", "order", "family", "genus", "species")
+    ranks <- c("domain", "supergroup", "division", "subdivision", "class", "order", "family", "genus", "species")
     colnames(yydf) <- ranks
     colnames(confdf) <- ranks
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ if (!requireNamespace("BiocManager", quietly = TRUE))
 BiocManager::install(c("DECIPHER", "Biostrings", "dada2"))
 
 library(devtools)
-devtools::install_github("dcat4/ensembleTax", build_manual = TRUE, build_vignettes = TRUE)
+devtools::install_github("morien/ensembleTax", build_manual = TRUE, build_vignettes = TRUE)
 packageVersion("ensembleTax")
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ if (!requireNamespace("BiocManager", quietly = TRUE))
 BiocManager::install(c("DECIPHER", "Biostrings", "dada2"))
 
 library(devtools)
-devtools::install_github("morien/ensembleTax", build_manual = TRUE, build_vignettes = TRUE)
+devtools::install_github("dcat4/ensembleTax", build_manual = TRUE, build_vignettes = TRUE)
 packageVersion("ensembleTax")
 ```
 


### PR DESCRIPTION
Since PR2 5.0.0 update, the PR2 example code didn't work for DECIPHER/IDTAXA output (this is true for PR2's own example method for generating a taxonomy table from DECIPHER output as well). In ensembleTax this only requires changing a few lines of code to remedy. I've done that. Your commented examples in the readme will also need to be adjusted a bit based on the updated PR2 ranks (domain, supergroup, division, subdivision, class, order, family, genus, species), but with my changes the idtax2df function works again and produces the correct output.